### PR TITLE
fix npm warning bugs['web'] should be bugs['url']

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,7 @@
 , "repository" :      { "type" :  "git",
                         "url" :   "https://github.com/zcbenz/node-gui.git"
                       }
-, "bugs" :            { "web" :   "https://github.com/zcbenz/node-gui/issues",
-                        "url" :   "https://github.com/zcbenz/node-gui/issues"
-                      }
-, "scripts" :         { "preinstall" : "node-waf configure",
-                        "install" : "node-waf build install"
-                      }
+, "bugs" :            { "url" :   "https://github.com/zcbenz/node-gui/issues" }
 , "os" :              [ "linux"
                       , "darwin"
                       , "freebsd"


### PR DESCRIPTION
Kept bugs['web'] because previous versions of npm might use it

```
$npm -v
1.0.99
$node -v
v0.5.9
```
